### PR TITLE
[fix]: 세팅 페이지 연속 일수 오류 해결

### DIFF
--- a/src/components/widget/setting/SettingProfile.tsx
+++ b/src/components/widget/setting/SettingProfile.tsx
@@ -49,7 +49,7 @@ const SettingProfile = () => {
               {mypage.answerRecord === 0 ? '오늘도' : '연속'}&nbsp;
             </TextP>
             <TextP typo="c_b" textColor="logo">
-              {mypage.answerRecord === 0 ? '진정한 나' : '1'}
+              {mypage.answerRecord === 0 ? '진정한 나' : mypage.answerRecord}
             </TextP>
             <TextP typo="c_b" textColor="gray6">
               {mypage.answerRecord === 0 ? '를 만나봐요!' : '일째 답변 중!'}


### PR DESCRIPTION
### 📃 전달 사항

세팅 페이지에 연속 일수 맞지 않는 오류 수정했습니다.
문자열을 넣어놨더라구요 ..!

### 📸 스크린샷

### ✔ 진행사항

- [x] 세팅 페이지 연속 일수 오류 해결

### 🔴 ETC

기타 사항을 적어주세요.
실제 개발 기간 :

<hr>

closes: #
