### PR TITLE
fix: 스크롤 시 자동스냅되는 현상 개선

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/space-before-function-paren": "off",
     "@typescript-eslint/triple-slash-reference": "off",
     "@typescript-eslint/restrict-template-expressions": "error",
-    "@typescript-eslint/strict-boolean-expressions": "off"
+    "@typescript-eslint/strict-boolean-expressions": "off",
+    "@typescript-eslint/no-unused-vars": "off"
   }
 }

--- a/src/components/widget/landing/LandingQuestion.tsx
+++ b/src/components/widget/landing/LandingQuestion.tsx
@@ -26,26 +26,26 @@ import { commonOpacityYAni } from 'styles/ani'
 
 const DummyNumber = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
+// slick setting
+const SETTINGS = {
+  centerMode: true,
+  dots: false,
+  infinite: true,
+  speed: 500,
+  variableWidth: true,
+  autoplay: true,
+  autoplaySpeed: 2000,
+  focusOnSelect: false,
+  swipe: false,
+  arrows: false,
+  pauseOnHover: false,
+  pauseOnFocus: false
+}
+
 const LandingQuestionInfo = () => {
   // hooks
   const windowSize = useWindowSize()
   const { ref, inView } = useInView({ triggerOnce: true, initialInView: false })
-
-  // slick setting
-  const settings = {
-    centerMode: true,
-    dots: false,
-    infinite: true,
-    speed: 500,
-    variableWidth: true,
-    autoplay: true,
-    autoplaySpeed: 2000,
-    focusOnSelect: false,
-    swipe: false,
-    arrows: false,
-    pauseOnHover: false,
-    pauseOnFocus: false
-  }
 
   // ref
   const infoRef = useRef<HTMLDivElement>(null)
@@ -158,6 +158,7 @@ const LandingQuestionInfo = () => {
             </TextH3>
           </Grid>
         </Grid>
+
         <TimeChanger
           ref={ref}
           flex="center"
@@ -201,6 +202,7 @@ const LandingQuestionInfo = () => {
               />
             </TimeText>
           </MinuteWrapper>
+
           <SecondWrapper flex="center">
             <TimeText typo="h1_b" textColor="side500">
               <SlotCounter
@@ -215,15 +217,17 @@ const LandingQuestionInfo = () => {
               />
             </TimeText>
           </SecondWrapper>
+
           <MeridiemWrapper _width="fit-content" flex="center">
             <TextP typo={mediaQuery(windowSize.width) === 'mobile' ? 'c_b' : 'h5_b'} textColor="side500">
               AM
             </TextP>
           </MeridiemWrapper>
         </TimeChanger>
+
         <QuestionChanger
           flex="center"
-          variants={commonOpacityYAni}
+          variants={QuestionChangerVariants}
           viewport={{ once: true }}
           initial="init"
           whileInView="ani"
@@ -238,8 +242,9 @@ const LandingQuestionInfo = () => {
             </QuestionBubble>
             <Icon.LandingQuestionList width={mediaQuery(windowSize.width) === 'mobile' ? '232px' : '375px'} />
           </QuestionList>
+
           <QuestionSlider>
-            <Slider {...settings}>
+            <Slider {...SETTINGS}>
               <Icon.LandingQuestion1 width={mediaQuery(windowSize.width) === 'mobile' ? '200px' : '325px'} />
               <Icon.LandingQuestion2 width={mediaQuery(windowSize.width) === 'mobile' ? '200px' : '325px'} />
               <Icon.LandingQuestion3 width={mediaQuery(windowSize.width) === 'mobile' ? '200px' : '325px'} />
@@ -376,3 +381,18 @@ const QuestionSlider = styled(Grid)`
     }
   }
 `
+
+const QuestionChangerVariants = {
+  init: {
+    opacity: 0,
+    y: 10
+  },
+  ani: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: 0.8,
+      duration: 0.3
+    }
+  })
+}

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -36,8 +36,8 @@ const LandingPage = () => {
 
 const LandingWrapper = styled(motion.main)`
   position: relative;
-  scroll-behavior: smooth;
-  scroll-snap-type: y mandatory;
+  /* scroll-behavior: smooth; */
+  /* scroll-snap-type: y mandatory; */
   height: 100vh;
   height: calc(var(--vh, 1vh) * 100);
   overflow: auto;


### PR DESCRIPTION
### 📃 전달 사항

스크롤 시 scroll-snap 속성으로 인하여 중간컨텐츠에 멈추면 자동 스냅시켜주어 스크롤을 부드럽게 보여주려 의도한 부분이 있었습니다.
마우스 스크롤시에는 문제가 없으나 노트북 터치패드로 스크롤시에 중간에 멈추면 자동으로 스냅시켜주어 사용자가 의도한 스크롤한 위치로 보여주지 못하는 이슈가 생겨 scroll-snap속성을 제거했습니다.


### 📸 스크린샷

### ✔ 진행사항

- [ ] done1
- [ ] done1

### 🔴 ETC

기타 사항을 적어주세요.
실제 개발 기간 :

<hr>

closes: #
